### PR TITLE
add feature to update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Storyblok Universal Sync CLI is a command-line interface tool designed to sy
 - `--sourceSpaceId`: The Space ID of the source Storyblok space. This is required.
 - `--targetSpaceId`: The Space ID of the target Storyblok space. This is required.
 - `--types`: Specify the types of content to sync. Supported types include 'assets', 'components', 'folders', 'stories'. You can specify multiple types by separating them with spaces. This is required.
+- `--experimental-updateUuids`: Each created story will get a new uuid from Storyblok. References between content types will fail. This feature creates a mapping and updates the reference. Could need an extra sync if referencing story is created/updated before the referenced story.
 
 ## How to Use
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -28,6 +28,14 @@ const argv = yargs
       "Types to sync including, 'assets', 'components', 'folders', 'stories' use space separated for multiple types",
     type: "array",
     demandOption: true,
+  })
+  .option("experimental-updateUuids", {
+    description:
+      "Update references to other content types in stories. \
+      Experimental feature, order of synced stories can be important. Rerunning the sync can help",
+    type: "boolean",
+    demandOption: false,
+    default: false
   }).argv;
 
 const {
@@ -36,6 +44,7 @@ const {
   sourceSpaceId,
   targetSpaceId,
   types,
+  experimentalUpdateUuids
 } = argv;
 
 const sourceClient = new StoryblokClient({
@@ -50,4 +59,5 @@ sync(types, {
   targetSpaceId: targetSpaceId,
   sourceClient: sourceClient,
   targetClient: targetClient,
+  updateUuids: experimentalUpdateUuids
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "p-series": "^2.1.0",
         "request": "^2.88.2",
         "storyblok-js-client": "^2.0.12",
+        "validator": "^13.12.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -686,6 +687,14 @@
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/verror": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "p-series": "^2.1.0",
     "request": "^2.88.2",
     "storyblok-js-client": "^2.0.12",
+    "validator": "^13.12.0",
     "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
When you have references in storyblok from one content type to another content type uuid's are used as reference. When posting new stories in the sync process, the stories gets a new uuid which breaks the reference.
As you can see in the changes in the readme the order is somewhat important so I labeled my feature experimental.
Hope it helps